### PR TITLE
maanas/reducepeakmem: cache parsed AST to prevent FileSet accumulation

### DIFF
--- a/astutil.go
+++ b/astutil.go
@@ -336,6 +336,7 @@ type Utils interface {
 	ParsePackages(pkgset ...*build.Package) ([]*ast.Package, error)
 	FindUniqueType(f ast.Filter, packageSet ...*build.Package) (*ast.TypeSpec, error)
 	FindFunction(f ast.Filter, pkgset ...*build.Package) (*ast.FuncDecl, error)
+	FindFunctionInPackages(f ast.Filter, pkgs ...*ast.Package) (*ast.FuncDecl, error)
 	WalkFiles(delegate func(path string, file *ast.File), pkgset ...*build.Package) error
 }
 
@@ -416,6 +417,10 @@ func (t utils) FindFunction(f ast.Filter, pkgset ...*build.Package) (*ast.FuncDe
 		return nil, err
 	}
 
+	return t.FindFunctionInPackages(f, pkgs...)
+}
+
+func (t utils) FindFunctionInPackages(f ast.Filter, pkgs ...*ast.Package) (*ast.FuncDecl, error) {
 	found := []*ast.FuncDecl{}
 	for _, pkg := range pkgs {
 		found = append(found, FindFunc(pkg)...)

--- a/generators/functions/functions.go
+++ b/generators/functions/functions.go
@@ -41,9 +41,9 @@ func DetectScanner(ctx generators.Context, fnt *ast.FuncType) (r *ast.FuncDecl) 
 		return s == types.ExprString(fnt.Results.List[0].Type)
 	}
 
-	util := genieql.NewSearcher(ctx.FileSet, ctx.CurrentPackage)
+	util := genieql.NewUtils(ctx.FileSet)
 
-	if r, err = util.FindFunction(test); err != nil {
+	if r, err = util.FindFunctionInPackages(test, ctx.CachedPackages()...); err != nil {
 		log.Println("failed to find scanner", types.ExprString(fnt.Results.List[0].Type))
 		return nil
 	}

--- a/generators/functions_query.go
+++ b/generators/functions_query.go
@@ -256,10 +256,10 @@ func extractOptionsFromParams(ctx Context, defaultedSet []string, fields ...*ast
 }
 
 func extractOptionsFromResult(ctx Context, field *ast.Field) (QueryFunctionOption, error) {
-	util := genieql.NewSearcher(ctx.FileSet, ctx.CurrentPackage)
-	scanner, err := util.FindFunction(func(s string) bool {
+	util := genieql.NewUtils(ctx.FileSet)
+	scanner, err := util.FindFunctionInPackages(func(s string) bool {
 		return s == types.ExprString(field.Type)
-	})
+	}, ctx.CachedPackages()...)
 
 	return QFOScanner(scanner), err
 }


### PR DESCRIPTION
DetectScanner was re-parsing the entire package directory on every call, accumulating file position data in the shared FileSet. For a codebase with 86 files like Voldemort, detecting N scanners meant parsing all 86 files N times into the same FileSet.

go/token.FileSet maintains an unbounded registry - it never releases file position mappings. Each redundant parse added duplicate entries, causing linear memory growth.

Now we parse once during Context creation and cache the AST. Scanner lookups use the cached packages instead of triggering new parses. The FileSet only holds positions from a single parse run.