### PR TITLE
duckdb: fall back to type name expression for unknown column types

### DIFF
--- a/internal/duckdb/duckdb.go
+++ b/internal/duckdb/duckdb.go
@@ -143,8 +143,8 @@ func columnInformation(d genieql.Driver, q queryer, query, table string) ([]geni
 
 		expr := totypeexpr(dataType)
 		if expr == nil {
-			log.Println("skipping column", name, "driver missing type", dataType, "please open an issue")
-			continue
+			log.Println("nonstandard column type", name, "unknown type identifier", dataType, "falling back to type name")
+			expr = astutil.Expr(dataType)
 		}
 
 		if columndef, err = d.LookupType(types.ExprString(expr)); err != nil {


### PR DESCRIPTION
introspection currently skips columns whose dataType is not in the hardcoded totypeexpr switch (FLOAT[N], DOUBLE[N], VARCHAR[], etc). the postgresql adapter already handles this case by falling back to astutil.Expr(tname) so driver.yml mappings can resolve the type via LookupType; this mirrors that pattern. without it, callers cannot generate code for columns of types like FLOAT[128] (duckdb VSS) even when they provide a driver.yml entry for them.